### PR TITLE
fix/github-link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ resume_section_associations:    true
 # Resume social links
 # uncomment the options you wish to display, and add your own URL
 resume_social_links:
-  resume_github_url:            "https://github.com/meg-ssk"
+  resume_github_url:            "https://github.com/s-sasaki-earthsea-wizard"
   resume_twitter_url:           "https://twitter.com/SaMeGiraffe_VRC"
   # resume_dribbble_url:          "https://dribbble.com/jag"
   # resume_facebook_url:          "insert Facebook URL here"


### PR DESCRIPTION
GitHubのリンクを個人用から事業用に変更。
個人アカウントのレポジトリはforkしておいた